### PR TITLE
fix path to sample recording

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ app.get('/history', (req, res) => {
     }, 4000);
 })
 
-app.get('/recording', (req, res) => {
+app.get('/recordings/example_transmission.mp3', (req, res) => {
   res.writeHead(200, {'Content-Type': 'audio/mpeg'});
   let opStream = fileSystem.createReadStream('./sample_recording.mp3');
   opStream.pipe(res)


### PR DESCRIPTION
I suggest changing this path to match the relative URL paths in `mock_data.json`.